### PR TITLE
fixed an issue with empty json

### DIFF
--- a/lib/acts_as_gmappable/base.rb
+++ b/lib/acts_as_gmappable/base.rb
@@ -123,8 +123,7 @@ module Gmaps4rails
         
         def to_gmaps4rails
           json = "["
-          json += Gmaps4rails.create_json(self).to_s
-          json.chop! #removes the extra comma
+          json += Gmaps4rails.create_json(self).to_s.chop #removes the extra comma
           json += "]"
         end
         


### PR DESCRIPTION
Hi,

i am using your gem for a few days now and i really like it. There was just one issue which broke my javascript code from time to time. If you want to display something that has no valid geocoordinates the method "to_gmaps4rails" will return "]" which breaks the js code. I just moved the "chop" call after the json creation so this problem should no longer occur. I tried to write a test for that, but your test-suite was not executable (rake test did not do anything and in textmate a got an error with the not existing widget.rb) so i did not include any testcase in the patch.

Hope you like what i did and i am looking forward to your next release.
thx
Andi
