### PR TITLE
Google wants colors expressed as #000000 and not as #000 nor as #0000

### DIFF
--- a/public/javascripts/gmaps4rails.js
+++ b/public/javascripts/gmaps4rails.js
@@ -43,10 +43,10 @@ var Gmaps4Rails = {
   
 	//Polygon Styling
 	polygons_conf: {						//default style for polygons
-		strokeColor: "#000",
+		strokeColor: "#FFAA00",
   	strokeOpacity: 0.8,
   	strokeWeight: 2,
-  	fillColor: "#000",
+    fillColor: "#000000",
   	fillOpacity: 0.35
 		},
 
@@ -59,9 +59,9 @@ var Gmaps4Rails = {
 		
 	//Circle Styling	
 	circles_conf: {							//default style for circles
-	  fillColor: "#000",
+	  fillColor: "#00AAFF",
 	  fillOpacity: 0.35,
-		strokeColor: "#0000",
+		strokeColor: "#FFAA00",
 	  strokeOpacity: 0.8,
 	  strokeWeight: 2
 		},


### PR DESCRIPTION
Hej!

Suddenly (one week ago) I had some issues with Google maps in my application: the circles where not displayed anymore.
I have eventually found out that in your .js default colors are expressed somehow in a way that is not what Google Maps expects.

ex: strokeColor: "#0000",

This patch fix the issues.
