### PR TITLE
Support for mongoid_geo

### DIFF
--- a/lib/acts_as_gmappable/base.rb
+++ b/lib/acts_as_gmappable/base.rb
@@ -146,8 +146,8 @@ module Gmaps4rails
           logger.warn(e)
           #TODO add customization here?
         else #if no exception
-          self[gmaps4rails_options[:lng_column]] = coordinates.first[:lng]
-          self[gmaps4rails_options[:lat_column]] = coordinates.first[:lat]
+          self.send(gmaps4rails_options[:lng_column]+"=", coordinates.first[:lng]) if self.respond_to?(gmaps4rails_options[:lng_column]+"=")
+          self.send(gmaps4rails_options[:lat_column]+"=", coordinates.first[:lat]) if self.respond_to?(gmaps4rails_options[:lat_column]+"=")
           unless gmaps4rails_options[:normalized_address].nil?
             self.send(gmaps4rails_options[:normalized_address].to_s+"=", coordinates.first[:matched_address])
           end
@@ -157,7 +157,7 @@ module Gmaps4rails
         end
       end
          
-      def to_gmaps4rails  
+      def to_gmaps4rails
         json = "["
         json += Gmaps4rails.create_json(self).to_s.chop.chop #removes the extra comma
         json += "]"


### PR DESCRIPTION
Now `Gmaps4rails.create_json` takes the values for latitude and longitude in this way:

``` ruby
object.send(object.gmaps4rails_options[:lat_column])
object.send(object.gmaps4rails_options[:lng_column])
```

Before this commit the method took those values in this way:

``` ruby
object[object.gmaps4rails_options[:lat_column]]
object[object.gmaps4rails_options[:lng_column]]
```
