### PR TITLE
Properly Encode Ampersand

### DIFF
--- a/app/views/gmaps4rails/_gmaps4rails.html.erb
+++ b/app/views/gmaps4rails/_gmaps4rails.html.erb
@@ -7,7 +7,7 @@ if enable_css == true %>
 
 <% content_for :scripts do %>
 <% if enable_js == true %>
-  <script type="text/javascript" src='http://maps.google.com/maps/api/js?sensor=false&libraries=geometry'></script>
+  <script type="text/javascript" src='http://maps.google.com/maps/api/js?sensor=false&amp;libraries=geometry'></script>
 	<script type="text/javascript" src='http://google-maps-utility-library-v3.googlecode.com/svn/tags/infobox/1.1.5/src/infobox.js'></script>
 	<%=javascript_include_tag 'gmaps4rails' %>
 	<script type="text/javascript" src='http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerclusterer/1.0/src/markerclusterer_compiled.js'></script>


### PR DESCRIPTION
Was getting w3c validation errors due to improperly coded ampersand for the url.
