### PR TITLE
Move initializer for ActsAsGmappable to Rails::Railtie

### DIFF
--- a/lib/gmaps4rails.rb
+++ b/lib/gmaps4rails.rb
@@ -21,7 +21,7 @@ if defined?(Rails) && Rails::VERSION::MAJOR == 3
     
     class Railtie < Rails::Railtie
     
-       initializer "aaa include acts_as_gmappable within ORM" do
+       initializer "include acts_as_gmappable within ORM" do
          ActiveSupport.on_load(:active_record) do
            ActiveRecord::Base.send(:include, Gmaps4rails::ActsAsGmappable)
          end


### PR DESCRIPTION
I do this to make sure when RailsAdmin run audit_with, 
the method "acts_as_gmappable" is defined / ActsAsGmappable is included already
