### PR TITLE
Move initializer for ActsAsGmappable from Rails::Engine to Rails::Railtie

### DIFF
--- a/lib/gmaps4rails.rb
+++ b/lib/gmaps4rails.rb
@@ -17,6 +17,10 @@ if defined?(Rails) && Rails::VERSION::MAJOR == 3
          end
        end
        
+    end
+    
+    class Railtie < Rails::Railtie
+    
        initializer "include acts_as_gmappable within ORM" do
          ActiveSupport.on_load(:active_record) do
            ActiveRecord::Base.send(:include, Gmaps4rails::ActsAsGmappable)
@@ -26,7 +30,7 @@ if defined?(Rails) && Rails::VERSION::MAJOR == 3
            Mongoid::Document.send(:include, Gmaps4rails::ActsAsGmappable)
          end
        end
-       
+    
     end
   end
 end


### PR DESCRIPTION
Moved initializer "include acts_as_gmappable within ORM" from Engine to Railte
To solve no method error when using RailsAdmin's history feature (config.audit_with)
