### PR TITLE
Added support for z-index in markers

### DIFF
--- a/app/assets/javascripts/gmaps4rails/gmaps4rails.base.js.coffee
+++ b/app/assets/javascripts/gmaps4rails/gmaps4rails.base.js.coffee
@@ -326,6 +326,7 @@ class @Gmaps4Rails
         "shadow_height":    if @markers[index].shadow_height  then @markers[index].shadow_height  else null
         "marker_draggable": if @markers[index].draggable      then @markers[index].draggable      else @markers_conf.draggable
         "rich_marker":      if @markers[index].rich_marker    then @markers[index].rich_marker    else null
+        "zindex":           if @markers[index].zindex         then @markers[index].zindex    else null
         "Lat":              Lat
         "Lng":              Lng
         "index":            index

--- a/app/assets/javascripts/gmaps4rails/gmaps4rails.googlemaps.js.coffee
+++ b/app/assets/javascripts/gmaps4rails/gmaps4rails.googlemaps.js.coffee
@@ -111,7 +111,7 @@ class @Gmaps4RailsGoogle extends Gmaps4Rails
     markerLatLng = @createLatLng(args.Lat, args.Lng)
     #Marker sizes are expressed as a Size of X,Y
     if args.marker_picture == "" and args.rich_marker == null
-      defaultOptions = {position: markerLatLng, map: @map, title: args.marker_title, draggable: args.marker_draggable}
+      defaultOptions = {position: markerLatLng, map: @map, title: args.marker_title, draggable: args.marker_draggable, zIndex: args.zindex}
       mergedOptions  = @mergeObjectWithDefault @markers_conf.raw, defaultOptions
       return new google.maps.Marker mergedOptions
 
@@ -123,6 +123,7 @@ class @Gmaps4RailsGoogle extends Gmaps4Rails
         content:   args.rich_marker
         flat:      if args.marker_anchor == null then false else args.marker_anchor[1]
         anchor:    if args.marker_anchor == null then 0     else args.marker_anchor[0]
+        zIndex:    args.zindex
       })
 
     #default behavior
@@ -132,7 +133,7 @@ class @Gmaps4RailsGoogle extends Gmaps4Rails
     #create or retrieve existing MarkerImages
     markerImage = @createOrRetrieveImage(args.marker_picture, args.marker_width, args.marker_height, imageAnchorPosition)
     shadowImage = @createOrRetrieveImage(args.shadow_picture, args.shadow_width, args.shadow_height, shadowAnchorPosition)
-    defaultOptions = {position: markerLatLng, map: @map, icon: markerImage, title: args.marker_title, draggable: args.marker_draggable, shadow: shadowImage}
+    defaultOptions = {position: markerLatLng, map: @map, icon: markerImage, title: args.marker_title, draggable: args.marker_draggable, shadow: shadowImage, zIndex: args.zindex}
     mergedOptions  = @mergeObjectWithDefault @markers_conf.raw, defaultOptions
     return new google.maps.Marker mergedOptions
 


### PR DESCRIPTION
Allows to set the z-index of markers so they would overlap with a custom priority.

Can be set like this

``` ruby
counter = 0
@json = User.all.to_gmaps4rails do |user, marker|
     marker.picture({
                     :picture => "http://www.blankdots.com/img/github-32x32.png",
                     :width   => "32",
                     :height  => "32",
                     :zindex =>  User.all.size - counter   # can be set here
                    })
     marker.title   "i'm the title"
     marker.sidebar "i'm the sidebar"
     marker.json({ :id => user.id, :zindex => User.all.size - counter}) # ...or here as well
     counter += 1
end
```

This would overlap the markers in order of insertion (first marker at top, last marker at bottom)
