### PR TITLE
Add replaceMarkerSet function which replaces markers subset

### DIFF
--- a/app/assets/javascripts/gmaps4rails/gmaps4rails.base.js.coffee
+++ b/app/assets/javascripts/gmaps4rails/gmaps4rails.base.js.coffee
@@ -358,6 +358,18 @@ class @Gmaps4Rails
     @markers_conf.offset = 0
     @addMarkers(new_markers)
 
+  replaceMarkerSet : (new_markers) ->
+    #create array with markers ids
+    toClear = []
+    for marker in new_markers
+      toClear.push(marker.id)
+    #clear markers
+    for marker in @markers
+      if marker.id in toClear
+        @clearMarker marker
+    #add markers
+    @addMarkers(new_markers)
+
   #add new markers to on an existing map
   addMarkers : (new_markers) ->
     #update the list of markers to take into account


### PR DESCRIPTION
Replacing one marker:

```
$ ->
  $('#replace_marker1').click ->
    $.getJSON(
      "/points/1.json",
      (data) ->
        Gmaps.map.replaceMarkerSet(data)
```

The subset of markers can be replaced exactly the same way, by submitting subset of markers via json.

Note: the issue #182 is not solved in this commit.
