### PR TITLE
Added provider_key to google maps

### DIFF
--- a/app/views/gmaps4rails/_scripts.html.erb
+++ b/app/views/gmaps4rails/_scripts.html.erb
@@ -7,7 +7,7 @@
   <% when "bing" %>
     <script type="text/javascript" src="http://ecn.dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=7.0"></script>
   <% else %>
-    <script type="text/javascript" src="//maps.google.com/maps/api/js?v=3.8&sensor=false&libraries=geometry<%= gmaps4rails_js_libraries(map_options.try(:[], :libraries)) %>&<%= gmaps4rails_map_language(map_options) %>"></script>
+    <script type="text/javascript" src="//maps.google.com/maps/api/js?v=3.8&sensor=false&key=<%= map_options.try(:[], :provider_key) %>&libraries=geometry<%= gmaps4rails_js_libraries(map_options.try(:[], :libraries)) %>&<%= gmaps4rails_map_language(map_options) %>"></script>
     <% if marker_options.try(:[], :custom_infowindow_class) %>
       <script type="text/javascript" src="//google-maps-utility-library-v3.googlecode.com/svn/tags/infobox/1.1.9/src/infobox_packed.js"></script>
     <% end %>


### PR DESCRIPTION
Some people need to be able to add the google maps api key for either business (have to include an api key in your requests) or tracking purposes (statistics available via google api located here: https://code.google.com/apis/console/b/0/). I'm in the latter category.

Another person who had a similar issue:
http://stackoverflow.com/questions/10092881/does-the-gmaps4rails-gem-for-rails-3-1-allow-use-of-a-google-maps-api-key

By default the gem is using google maps, so any key provided will be put against the google maps api. If no key is provided we stick with just a blank &key=
