### PR TITLE
Google maps clusterer bug

### DIFF
--- a/lib/gmaps4rails/view_helper.rb
+++ b/lib/gmaps4rails/view_helper.rb
@@ -70,7 +70,7 @@ module Gmaps4rails
       else #case googlemaps which is the default
         @js_array << "#{GOOGLE}&sensor=false&key=#{provider_key}&libraries=geometry#{google_libraries}&#{google_map_i18n}"
         @js_array << "#{GOOGLE_EXT}tags/infobox/1.1.9/src/infobox_packed.js"                     if custom_infowindow_class
-        @js_array << "#{GOOGLE_EXT}tags/markerclustererplus/2.0.5/src/markerclusterer_packed.js" if do_clustering
+        @js_array << "#{GOOGLE_EXT}tags/markerclustererplus/2.0.9/src/markerclusterer_packed.js" if do_clustering
         @js_array << "#{GOOGLE_EXT}trunk/richmarker/src/richmarker-compiled.js"                  if rich_marker
       end
     end


### PR DESCRIPTION
Hi Benjamin!

While working with your gem i noticed that the markers don't get clustered at a certain zoom level (as described here http://stackoverflow.com/questions/9565242/markerclusterer-google-maps-api-v3-bug-markers-partitially-not-clustered-in-z). I updated the MarkerClustererPlus version. Now it works properly.

Sincerely,
Ismail
