### PR TITLE
Added client option to google maps url

### DIFF
--- a/lib/gmaps4rails/view_helper.rb
+++ b/lib/gmaps4rails/view_helper.rb
@@ -66,7 +66,7 @@ module Gmaps4rails
       when "mapquest"    then @js_array << "#{MAPQUEST}?key=#{provider_key}"
       when "bing"        then @js_array << BING
       else #case googlemaps which is the default
-        @js_array << "#{GOOGLE}&sensor=false&key=#{provider_key}&libraries=geometry#{google_libraries}&#{google_map_i18n}"
+        @js_array << "#{GOOGLE}&sensor=false&client=#{client}&key=#{provider_key}&libraries=geometry#{google_libraries}&#{google_map_i18n}"
         @js_array << "#{GOOGLE_EXT}tags/infobox/1.1.9/src/infobox_packed.js"                      if custom_infowindow_class
         @js_array << "#{GOOGLE_EXT}tags/markerclustererplus/2.0.9/src/markerclusterer_packed.js"  if do_clustering
         @js_array << "#{GOOGLE_EXT}trunk/richmarker/src/richmarker-compiled.js"                   if rich_marker
@@ -110,6 +110,10 @@ module Gmaps4rails
     # - anything else which would default to googlemaps
     def provider_key
       map_options.try(:[], :provider_key)
+    end
+
+    def client
+      map_options.try(:[], :client)
     end
     
     # when custom_infowindow_class is added in the marker_options,


### PR DESCRIPTION
Google maps for business needs a client id which is different from the api key. 

I have added the client parameter whose implementation is similar to provider_key. It does not break any existing implementation.

Thanks,
Ajay
