### PR TITLE
Added a geolocationSuccess() callback function

### DIFF
--- a/app/assets/javascripts/gmaps4rails/gmaps4rails.base.js.coffee
+++ b/app/assets/javascripts/gmaps4rails/gmaps4rails.base.js.coffee
@@ -24,6 +24,7 @@ class @Gmaps4Rails
     @userLocation = null       #contains user's location if geolocalization was performed and successful
 
     #empty slots
+    @geolocationSuccess = -> false  #triggered when geolocation succeeds. Can be customized.
     @geolocationFailure = -> false  #triggered when geolocation fails. If customized, must be like= function(navigator_handles_geolocation){} where 'navigator_handles_geolocation' is a boolean
     @callback           = -> false  #to let user set a custom callback function
     @customClusterer    = -> false  #to let user set custom clusterer pictures
@@ -95,6 +96,7 @@ class @Gmaps4Rails
         #change map's center to focus on user's geoloc if asked
         if(map_object.map_options.center_on_user == true)
           map_object.centerMapOnUser()
+        map_object.geolocationSuccess()
       positionFailure = ->
         map_object.geolocationFailure(true)
 


### PR DESCRIPTION
Personally I needed a success callback function for geolocation in Gmaps4Rails. I think this is useful for other users as well. It adds no further complexity to Gmaps4Rails.
It works completely analogously to `geolocationFailure()`.
