### PR TITLE
marker_anchor options are ignored

### DIFF
--- a/vendor/assets/javascripts/gmaps4rails/google/objects/marker.coffee
+++ b/vendor/assets/javascripts/gmaps4rails/google/objects/marker.coffee
@@ -56,8 +56,8 @@ class Gmaps4Rails.Google.Marker extends Gmaps4Rails.Common
       map:       @getMap()
       draggable: args.marker_draggable
       content:   args.rich_marker
-      flat:      if args.marker_anchor? ? args.marker_anchor[1] else false
-      anchor:    if args.marker_anchor? ? args.marker_anchor[0] else null
+      flat:      if args.marker_anchor? then args.marker_anchor[1] else false
+      anchor:    if args.marker_anchor? then args.marker_anchor[0] else null
       zIndex:    args.zindex
     })
 


### PR DESCRIPTION
Just noticed this today working with RichMarker, the CoffeeScript syntax actually works, but  the first option doesn't return the correct value:

For example if `args.marker_anchor` is `[1, true]`

``` coffeescript
if args.marker_anchor? ? args.marker_anchor[1] else false
#=> undefined
```

vs what we really wanted which is:

``` coffeescript
if args.marker_anchor? then args.marker_anchor[1] else false
#=> true
```
