### PR TITLE
google maps channel id support

### DIFF
--- a/lib/gmaps4rails/view_helper.rb
+++ b/lib/gmaps4rails/view_helper.rb
@@ -66,7 +66,7 @@ module Gmaps4rails
       when "mapquest"    then @js_array << "#{MAPQUEST}?key=#{provider_key}"
       when "bing"        then @js_array << BING
       else #case googlemaps which is the default
-        @js_array << "#{GOOGLE}&sensor=false&client=#{client}&key=#{provider_key}&libraries=geometry#{google_libraries}&#{google_map_i18n}"
+        @js_array << "#{GOOGLE}&sensor=false&client=#{client}&channel=#{channel}&key=#{provider_key}&libraries=geometry#{google_libraries}&#{google_map_i18n}"
         @js_array << "#{GOOGLE_EXT}tags/infobox/1.1.9/src/infobox_packed.js"                      if custom_infowindow_class
         @js_array << "#{GOOGLE_EXT}tags/markerclustererplus/2.0.14/src/markerclusterer_packed.js" if do_clustering
         @js_array << "#{GOOGLE_EXT}trunk/richmarker/src/richmarker-compiled.js"                   if rich_marker
@@ -153,6 +153,11 @@ module Gmaps4rails
     def client
       map_options.try(:[], :client)
     end
+
+    def channel
+      map_options.try(:[], :channel)
+    end
+    
     
     def map_id
       map_options.try(:[], :id) || Gmaps4rails::JsBuilder::DEFAULT_MAP_ID


### PR DESCRIPTION
add support for a map_option :channel

Google introduced a channel id parameter used to track API usage across websites with the same client id. We should add it as a map_option.
