### PR TITLE
Bump API version to support visualRefresh

### DIFF
--- a/lib/gmaps4rails/view_helper.rb
+++ b/lib/gmaps4rails/view_helper.rb
@@ -5,9 +5,8 @@ module Gmaps4rails
     OPENLAYERS = "http://www.openlayers.org/api/OpenLayers.js"
     MAPQUEST   = "http://www.mapquestapi.com/sdk/js/v7.0.s/mqa.toolkit.js"                  
     BING       = "http://ecn.dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=7.0"
-    GOOGLE     = "//maps.google.com/maps/api/js?v=3.9"
-    GOOGLE_EXT = "//google-maps-utility-library-v3.googlecode.com/svn/"    
-    
+    GOOGLE     = "//maps.google.com/maps/api/js?v=3.12"
+    GOOGLE_EXT = "//google-maps-utility-library-v3.googlecode.com/svn/"
     # options is the hash passed to the 'gmaps' helper
     # looks like:
     #{  


### PR DESCRIPTION
Google has enabled opt in for their [visual refresh](https://developers.google.com/maps/documentation/javascript/basics#VisualRefresh) by adding `google.maps.visualRefresh=true`, but this option does not work on version 3.9 of the API which is currently being used. 
