### PR TITLE
Add ability to set layout scripts block name in config

### DIFF
--- a/app/views/gmaps4rails/_gmaps4rails.html.erb
+++ b/app/views/gmaps4rails/_gmaps4rails.html.erb
@@ -1,4 +1,4 @@
-<% content_for :scripts do %>
+<% content_for Gmaps4rails::script_block.to_sym do %>
 <%= javascript_include_tag *js_dependencies %>
 
 <script type="text/javascript">

--- a/lib/gmaps4rails/base.rb
+++ b/lib/gmaps4rails/base.rb
@@ -22,9 +22,10 @@ module Gmaps4rails
   autoload :Places,           'gmaps4rails/api_wrappers/places'
   autoload :ObjectAccessor,   'gmaps4rails/object_accessor'
 
-  mattr_accessor :http_proxy, :escape_js_url
+  mattr_accessor :http_proxy, :escape_js_url, :script_block
 
   self.escape_js_url = true
+  self.script_block = :scripts
   
   # This method geocodes an address using the GoogleMaps webservice
   # options are:


### PR DESCRIPTION
I moved scripts block name to config, because I think its a bad idea to hardcode block where should js be. For example if I want it to go in head or body, and I do not want to create another one in layout file. Or, lets say I actually do not have access to layout, lets say it is created by some factory code, like in active admin.
