### PR TITLE
Add check for pipeline_enabled? that works for Rails 4

### DIFF
--- a/lib/gmaps4rails/base.rb
+++ b/lib/gmaps4rails/base.rb
@@ -121,7 +121,9 @@ module Gmaps4rails
   # works for Rails 3.0.x and above
   # @return [Boolean]
   def Gmaps4rails.pipeline_enabled?
-    Rails.configuration.respond_to?('assets') && Rails.configuration.assets.enabled
+    return false unless Rails.configuration.respond_to?('assets')
+    assets = Rails.configuration.assets
+    assets.enabled.nil? || assets.enabled
   end
-  
+
 end


### PR DESCRIPTION
Rails 4 removes the `enabled` flag from Rails.configuration.assets. This pull request updates `Gmaps4rails.pipeline_enabled?` to work for both Rails 3 and 4.

See rails/rails#10334
