### PR TITLE
add the ability to addPolylines (like addMarkers)

### DIFF
--- a/app/assets/javascripts/gmaps4rails/gmaps4rails.base.js.coffee
+++ b/app/assets/javascripts/gmaps4rails/gmaps4rails.base.js.coffee
@@ -394,6 +394,14 @@ class @Gmaps4Rails
     #.... and adjust map boundaries
     @adjustMapToBounds()
 
+  #add new polylines to on an existing map
+  addPolylines : (new_polylines, adjustBounds = true) ->
+    #update the list of polylines to take into account
+    @polylines = new_polylines
+    #put polylines on the map
+    @create_polylines()
+    @adjustMapToBounds() if adjustBounds
+
   destroy_polylines : ->
     for polyline in @polylines
       #delete polylines from map


### PR DESCRIPTION
I've effectively duplicated addMarkers for Polylines.
The main difference between replacePolylines and addPolylines is that @destroy_polylines() is not called.
This also includes the ability to optionally call @adjustMapToBounds().
