### PR TITLE
Removes unicode characters from example script links

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,9 +40,9 @@ Add a div to bear your map, example:
 
 Insert google scripts in your dom:
 
-    <script src="//maps.google.com/maps/api/js?v=3.18&sensor=false&client=&key=&libraries=ge‌​ometry&language=&hl=&region="></script> 
-    <script src="//google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplu‌​s/2.0.14/src/markerclusterer_packed.js"></script>
-    <script src='//google-maps-utility-library-v3.googlecode.com/svn/tags/infobox/1.1.9/src/‌​infobox_packed.js' type='text/javascript'></script> <!-- only if you need custom infoboxes -->
+    <script src="//maps.google.com/maps/api/js?v=3.18&sensor=false&client=&key=&libraries=geometry&language=&hl=&region="></script> 
+    <script src="//google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.0.14/src/markerclusterer_packed.js"></script>
+    <script src='//google-maps-utility-library-v3.googlecode.com/svn/tags/infobox/1.1.9/src/infobox_packed.js' type='text/javascript'></script> <!-- only if you need custom infoboxes -->
 
 You'll require underscore.js too, see here: {http://underscorejs.org/}[http://underscorejs.org/] (`lo-dash` is compatible too, your choice!).
 


### PR DESCRIPTION
These characters cause the links not to be friendly to copy and paste. The github diffs don't show the characters that were removed, see the screenshot from Vim below.

<img width="452" alt="screen shot 2015-11-09 at 9 52 10 am" src="https://cloud.githubusercontent.com/assets/12819656/11036608/9ac9d4aa-86c7-11e5-9557-9b69fcc2369a.png">
