### PR TITLE
Changes the google maps api script url

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,7 +40,7 @@ Add a div to bear your map, example:
 
 Insert google scripts in your dom:
 
-    <script src="//maps.google.com/maps/api/js?v=3.23&sensor=false&client=&key=&libraries=geometry&language=&hl=&region="></script> 
+    <script src="//maps.google.com/maps/api/js?v=3.23&key=[your API key]"></script>
     <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
     <script src='//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js' type='text/javascript'></script> <!-- only if you need custom infoboxes -->
 


### PR DESCRIPTION
The current url gives some warnings because it has options with empty values.

![screenshot from 2016-06-01 14 06 30](https://cloud.githubusercontent.com/assets/1001717/15718925/05d6a77c-2804-11e6-8d41-bb6b21ed15b5.png)

Changing it to something like this:

//maps.google.com/maps/api/js?v=3.23&key=AIzaSyCsB7TF5KvEf9lLZyDlhdwmXI7ohZgM9Qk"

Clears the warnings.

It's a little change but, fixes annoying messages.