### PR TITLE
Fix CDN URLs for infobox, etc.

### DIFF
--- a/lib/gmaps4rails/view_helper.rb
+++ b/lib/gmaps4rails/view_helper.rb
@@ -67,9 +67,9 @@ module Gmaps4rails
       when "bing"        then @js_array << BING
       else #case googlemaps which is the default
         @js_array << "#{GOOGLE}&sensor=false&client=#{client}&key=#{provider_key}&libraries=geometry#{google_libraries}&#{google_map_i18n}"
-        @js_array << "#{GOOGLE_EXT}tags/infobox/1.1.9/src/infobox_packed.js"                      if custom_infowindow_class
-        @js_array << "#{GOOGLE_EXT}tags/markerclustererplus/2.0.14/src/markerclusterer_packed.js" if do_clustering
-        @js_array << "#{GOOGLE_EXT}trunk/richmarker/src/richmarker-compiled.js"                   if rich_marker
+        @js_array << "https://cdn.rawgit.com/googlemaps/v3-utility-library/master/infobox/src/infobox_packed.js"  if custom_infowindow_class
+        @js_array << "https://cdn.rawgit.com/googlemaps/v3-utility-library/markerclustererplus/2.0.9/src/markerclusterer_packed.js"  if do_clustering
+        @js_array << "https://cdn.rawgit.com/googlemaps/v3-utility-library/master/richmarker/src/richmarker-compiled.js"  if rich_marker
       end
     end
     


### PR DESCRIPTION
Benjamin, per e-mail discussion, I have modified view_helper.rb in my forked repo
to reference new CDN URLs for infobox and other javascript resources that Google
move earlier last month.  

Once you merge these changes to 1.x, will "gem install" pick them up?

Thanks,
kodecharlie
